### PR TITLE
Routines for determining "Scratch Buffer Length"

### DIFF
--- a/OfflineDumpPkg/Library/OfflineDumpLib/RedactionScratchBufferLength.c
+++ b/OfflineDumpPkg/Library/OfflineDumpLib/RedactionScratchBufferLength.c
@@ -4,8 +4,11 @@
 #include <OfflineDumpLib.h>
 #include <Library/OfflineDumpRedactionMapInternal.h>
 
-#define PAGE_SHIFT     12u
-#define BITS_PER_BYTE  8
+#include <Library/DebugLib.h>
+
+#define PAGE_SHIFT           12u
+#define PAGE_SIZE            (1u << PAGE_SHIFT)
+#define CONTEXT_INITIALIZED  0xA1
 
 EFI_STATUS
 GetOfflineDumpRedactionScratchBufferLength (
@@ -13,24 +16,111 @@ GetOfflineDumpRedactionScratchBufferLength (
   OUT UINT32  *pLength
   )
 {
-  static UINT32 const  Table0Size = 4 * 1024; // Minimal 4KB Table0 covers addresses up to 0xFFFFFFFFFFFFF.
+  UINT32      Length;
+  EFI_STATUS  Status;
 
-  static UINT32 const    Table1Size            = BITMAPS_PER_TABLE1 * sizeof (UINT32); // Size in indexes * 4 bytes per index = size in bytes
-  static unsigned const  AddressPerTable1Shift = BITS_PER_TABLE1_SHIFT + PAGE_SHIFT;   // 2^42 = 4TB
+  if (MAX_UINT64 == HighestPhysicalAddress) {
+    Length = MAX_UINT32;
+    Status = EFI_INVALID_PARAMETER;
+  } else {
+    OFFLINE_DUMP_REDACTION_SCRATCH_BUFFER_LENGTH_CONTEXT  Context;
+    OfflineDumpRedactionScratchBufferLength_Init (&Context);
+    OfflineDumpRedactionScratchBufferLength_AddMemRange (&Context, 0, HighestPhysicalAddress + 1);
 
-  static UINT32 const    BitmapSize            = BITS_PER_BITMAP / BITS_PER_BYTE;    // size in bits / 8 bits per byte = size in bytes
-  static unsigned const  AddressPerBitmapShift = BITS_PER_BITMAP_SHIFT + PAGE_SHIFT; // 2^32 = 4GB
+    UINT64  Length64;
+    if (EFI_ERROR (OfflineDumpRedactionScratchBufferLength_Get (&Context, &Length64)) ||
+        (Length64 > MAX_UINT32))
+    {
+      Length = MAX_UINT32;
+      Status = EFI_INVALID_PARAMETER;
+    } else {
+      Length = (UINT32)Length64;
+      Status = EFI_SUCCESS;
+    }
+  }
 
-  // Larger addresses require more than 4GB of scratch space.
-  if (HighestPhysicalAddress > 0x7FFDFFFFFFFF) {
-    *pLength = 0xFFFFF000; // Largest valid scratch space size.
+  *pLength = Length;
+  return Status;
+}
+
+void
+OfflineDumpRedactionScratchBufferLength_Init (
+  OUT OFFLINE_DUMP_REDACTION_SCRATCH_BUFFER_LENGTH_CONTEXT  *pContext
+  )
+{
+  pContext->LastPageNum = -1;
+  pContext->BitmapCount = 0;
+  pContext->Table1Count = 0;
+  pContext->Initialized = CONTEXT_INITIALIZED;
+  pContext->AnyErrors   = FALSE;
+}
+
+EFI_STATUS
+OfflineDumpRedactionScratchBufferLength_AddMemRange (
+  IN OUT OFFLINE_DUMP_REDACTION_SCRATCH_BUFFER_LENGTH_CONTEXT  *pContext,
+  IN UINT64                                                    BaseAddress,
+  IN UINT64                                                    Length
+  )
+{
+  ASSERT (CONTEXT_INITIALIZED == pContext->Initialized);
+
+  INT64 const  BeginPageNum = BaseAddress >> PAGE_SHIFT;
+  INT64 const  PageCount    = Length >> PAGE_SHIFT;
+  INT64 const  EndPageNum   = BeginPageNum + PageCount;
+
+  if ((CONTEXT_INITIALIZED != pContext->Initialized) || // Context not initialized.
+      (0 != (BaseAddress & (PAGE_SIZE - 1))) ||         // BaseAddress not aligned to PAGE_SIZE.
+      (0 != (Length & (PAGE_SIZE - 1)))  ||             // Length not aligned to PAGE_SIZE.
+      (BeginPageNum < pContext->LastPageNum) ||         // Ranges overlap or out of order.
+      (EndPageNum > MAX_BITS_PER_TABLE0))               // 56-bit address space limit.
+  {
+    pContext->AnyErrors = TRUE;
     return EFI_INVALID_PARAMETER;
   }
 
-  UINT32  RequiredBytes = Table0Size;  // Minimal 4KB Table0.
-  RequiredBytes += (UINT32)((HighestPhysicalAddress >> AddressPerTable1Shift) + 1) * Table1Size;
-  RequiredBytes += (UINT32)((HighestPhysicalAddress >> AddressPerBitmapShift) + 1) * BitmapSize;
+  if (PageCount != 0) {
+    if ((pContext->LastPageNum >> BITS_PER_BITMAP_SHIFT) != (BeginPageNum >> BITS_PER_BITMAP_SHIFT)) {
+      pContext->BitmapCount += 1; // New Bitmap chunk.
+    }
 
-  *pLength = RequiredBytes;
+    if ((pContext->LastPageNum >> BITS_PER_TABLE1_SHIFT) != (BeginPageNum >> BITS_PER_TABLE1_SHIFT)) {
+      pContext->Table1Count += 1; // New Table1 chunk.
+    }
+
+    pContext->LastPageNum  = EndPageNum;
+    pContext->BitmapCount += (UINT32)((PageCount - 1) >> BITS_PER_BITMAP_SHIFT);
+    pContext->Table1Count += (UINT16)((PageCount - 1) >> BITS_PER_TABLE1_SHIFT);
+  }
+
   return EFI_SUCCESS;
+}
+
+EFI_STATUS
+OfflineDumpRedactionScratchBufferLength_Get (
+  IN OFFLINE_DUMP_REDACTION_SCRATCH_BUFFER_LENGTH_CONTEXT const  *pContext,
+  OUT UINT64                                                     *pLength
+  )
+{
+  EFI_STATUS  Status;
+  UINT64      Length;
+
+  ASSERT (CONTEXT_INITIALIZED == pContext->Initialized);
+
+  if ((CONTEXT_INITIALIZED != pContext->Initialized) || pContext->AnyErrors) {
+    Length = MAX_UINT64;
+    Status = EFI_INVALID_PARAMETER;
+  } else {
+    UINT32 const  Table0Items  = (UINT32)DIVIDE_AND_ROUND_UP (pContext->LastPageNum, BITS_PER_TABLE1);
+    UINT32 const  Table0Bytes  = Table0Items * sizeof (CHUNK_NUM);
+    UINT32 const  Table0Chunks = DIVIDE_AND_ROUND_UP (Table0Bytes, BYTES_PER_CHUNK);
+
+    Length =
+      TABLE0_CHUNK_SIZE * Table0Chunks +
+      TABLE1_SIZE * pContext->Table1Count +
+      (UINT64)BITMAP_SIZE * pContext->BitmapCount;
+    Status = EFI_SUCCESS;
+  }
+
+  *pLength = Length;
+  return Status;
 }

--- a/OfflineDumpPkg/Private/Library/OfflineDumpRedactionMap.h
+++ b/OfflineDumpPkg/Private/Library/OfflineDumpRedactionMap.h
@@ -62,16 +62,16 @@ struct _offline_dump_redaction_map_CHUNK;
 
 // Redaction map structure. Treat as opaque.
 typedef struct {
-    UINT64 MaxPageNum;   // Page numbers with this value or higher are not redacted.
-    struct _offline_dump_redaction_map_CHUNK* pBufferChunks; // Table0 starts at pBufferChunks[0].
-    UINT32 MaxBufferChunks; // pBufferChunks is OFFLINE_DUMP_REDACTION_MAP_CHUNK[MaxBufferChunks].
-    UINT32 UsedBufferChunks;// Next unused chunk is pBufferChunks[UsedBufferChunks].
+  UINT64                                      MaxPageNum;       // Page numbers with this value or higher are not redacted.
+  struct _offline_dump_redaction_map_CHUNK    *pBufferChunks;   // Table0 starts at pBufferChunks[0].
+  UINT32                                      MaxBufferChunks;  // pBufferChunks is OFFLINE_DUMP_REDACTION_MAP_CHUNK[MaxBufferChunks].
+  UINT32                                      UsedBufferChunks; // Next unused chunk is pBufferChunks[UsedBufferChunks].
 } OFFLINE_DUMP_REDACTION_MAP;
 
 // Returned by OfflineDumpRedactionMap_GetFirstRedactedRange(pMap, BeginPageNum, EndPageNum).
 typedef struct {
-    UINT64 BeginRedactedPageNum;
-    UINT64 EndRedactedPageNum;
+  UINT64    BeginRedactedPageNum;
+  UINT64    EndRedactedPageNum;
 } OFFLINE_DUMP_REDACTION_MAP_RANGE;
 
 #ifdef __cplusplus
@@ -91,12 +91,24 @@ MaxPageNum: 1 + highest PageNum that could possibly be redacted, e.g. 0x10000000
             physical address space).
 */
 EFI_STATUS
-OfflineDumpRedactionMap_Init(
-    OUT OFFLINE_DUMP_REDACTION_MAP* pMap,
-    IN void* pBuffer,
-    IN UINTN BufferSize,
-    IN UINT64 MaxPageNum
-);
+OfflineDumpRedactionMap_Init (
+  OUT OFFLINE_DUMP_REDACTION_MAP  *pMap,
+  IN void                         *pBuffer,
+  IN UINTN                        BufferSize,
+  IN UINT64                       MaxPageNum
+  );
+
+/*
+Marks the specified page as exposed (unredacted).
+
+This function is for exposing a single page. Use
+OfflineDumpRedactionMap_MarkRange to redact a page or to mark a range of pages.
+*/
+void
+OfflineDumpRedactionMap_ExposePage (
+  IN OUT OFFLINE_DUMP_REDACTION_MAP  *pMap,
+  IN UINT64                          PageNum
+  );
 
 /*
 Marks the specified pages as redacted or exposed.
@@ -105,12 +117,12 @@ Fails if FirstPageNum >= OfflineDumpRedactionMapMaxPageNumber(pMap)
 or if IsRedacted and map is out of buffer space.
 */
 EFI_STATUS
-OfflineDumpRedactionMap_Mark(
-    IN OUT OFFLINE_DUMP_REDACTION_MAP* pMap,
-    IN BOOLEAN IsRedacted,
-    IN UINT64 BeginPageNum,
-    IN UINT64 EndPageNum
-);
+OfflineDumpRedactionMap_MarkRange (
+  IN OUT OFFLINE_DUMP_REDACTION_MAP  *pMap,
+  IN BOOLEAN                         IsRedacted,
+  IN UINT64                          BeginPageNum,
+  IN UINT64                          EndPageNum
+  );
 
 /*
 Returns TRUE if the specified page is redacted, FALSE otherwise.
@@ -120,10 +132,10 @@ This function is for testing a single page. Use
 OfflineDumpRedactionMap_GetFirstRedactedRange to test a range of pages.
 */
 BOOLEAN
-OfflineDumpRedactionMap_IsRedacted(
-    IN OFFLINE_DUMP_REDACTION_MAP const* pMap,
-    IN UINT64 PageNum
-);
+OfflineDumpRedactionMap_IsRedacted (
+  IN OFFLINE_DUMP_REDACTION_MAP const  *pMap,
+  IN UINT64                            PageNum
+  );
 
 /*
 Finds the first redacted range in the specified page range.
@@ -141,20 +153,20 @@ Partitions the provided page range BeginPageNum..EndPageNum into three ranges:
   OfflineDumpRedactionMap_GetFirstRedactedRange again if this range is not empty).
 */
 OFFLINE_DUMP_REDACTION_MAP_RANGE
-OfflineDumpRedactionMap_GetFirstRedactedRange(
-    IN OFFLINE_DUMP_REDACTION_MAP const* pMap,
-    IN UINT64 BeginPageNum,
-    IN UINT64 EndPageNum
-);
+OfflineDumpRedactionMap_GetFirstRedactedRange (
+  IN OFFLINE_DUMP_REDACTION_MAP const  *pMap,
+  IN UINT64                            BeginPageNum,
+  IN UINT64                            EndPageNum
+  );
 
 /*
 Returns the value of MaxPageNum that was passed to OfflineDumpRedactionMapInit, or 0
 if OfflineDumpRedactionMapInit failed.
 */
 UINT64
-OfflineDumpRedactionMap_MaxPageNumber(
-    IN OFFLINE_DUMP_REDACTION_MAP const* pMap
-);
+OfflineDumpRedactionMap_MaxPageNumber (
+  IN OFFLINE_DUMP_REDACTION_MAP const  *pMap
+  );
 
 #ifdef __cplusplus
 } // extern "C"

--- a/OfflineDumpPkg/Private/Library/OfflineDumpRedactionMapInternal.h
+++ b/OfflineDumpPkg/Private/Library/OfflineDumpRedactionMapInternal.h
@@ -37,6 +37,16 @@ For use by tests and tools.
 // Each TABLE1 contains 2^30 = 1G bits, covering 2^42 = 4TB.
 #define BITS_PER_TABLE1              (1u << BITS_PER_TABLE1_SHIFT)
 
+// Each TABLE0 chunk contains 2^10 = 1K TABLE1s, covering 2^52 == 4PB.
+#define TABLE1_PER_TABLE0_CHUNK_SHIFT 10u
+// Each TABLE0 chunk contains 2^10 = 1K TABLE1s, covering 2^52 == 4PB.
+#define TABLE1_PER_TABLE0_CHUNK       (1u << TABLE1_PER_TABLE0_CHUNK_SHIFT)
+
+// Each TABLE0 chunk contains 2^40 = 1T bits, covering 2^52 == 4PB.
+#define BITS_PER_TABLE0_CHUNK_SHIFT (BITS_PER_TABLE1_SHIFT + TABLE1_PER_TABLE0_CHUNK_SHIFT)
+// Each TABLE0 chunk contains 2^40 = 1T bits, covering 2^52 == 4PB.
+#define BITS_PER_TABLE0_CHUNK       (1ull << BITS_PER_TABLE0_CHUNK_SHIFT)
+
 // Each TABLE0 contains up to 2^14 == 16K TABLE1 INDEXs, covering 2^56 bytes.
 #define MAX_TABLE1S_PER_TABLE0_SHIFT 14u
 // Each TABLE0 contains up to 2^14 == 16K TABLE1 INDEXs, covering 2^56 bytes.
@@ -46,6 +56,22 @@ For use by tests and tools.
 #define MAX_BITS_PER_TABLE0_SHIFT    (BITS_PER_TABLE1_SHIFT + MAX_TABLE1S_PER_TABLE0_SHIFT)
 // Each TABLE0 contains up to 2^44 bits, covering 2^56 bytes.
 #define MAX_BITS_PER_TABLE0          (1ull << MAX_BITS_PER_TABLE0_SHIFT)
+
+// Each TABLE0 chunk is 4KB.
+#define TABLE0_CHUNK_SIZE            4096u
+// Each TABLE1 is 4KB.
+#define TABLE1_SIZE                  4096u
+// Each BITMAP is 128KB.
+#define BITMAP_SIZE                 (128u * 1024u)
+
+// (Value + DivisorMacro - 1) >> DivisorMacro_SHIFT
+#define DIVIDE_AND_ROUND_UP(Value, DivisorMacro) \
+    ((Value + DivisorMacro - 1u) >> (DivisorMacro##_SHIFT))
+
+#define BYTES_PER_CHUNK_SHIFT  12u
+#define BYTES_PER_CHUNK        (1u << BYTES_PER_CHUNK_SHIFT)
+
+typedef UINT32 CHUNK_NUM;
 
 STATIC_ASSERT(
     MAX_BITS_PER_TABLE0_SHIFT == 44,

--- a/OfflineDumpPkg/Test/RedactionScratchBufferLengthTest.cpp
+++ b/OfflineDumpPkg/Test/RedactionScratchBufferLengthTest.cpp
@@ -8,7 +8,7 @@ static void
 TestSimple(UINT64 highestPhysicalAddress, unsigned table1s, unsigned bitmaps)
 {
     UINT32 expectedSize = 4 * 1024 + (table1s * 4 * 1024) + (bitmaps * 128 * 1024);
-    UINT32 size;
+    UINT32 size = ~expectedSize;
     TestAssert(EFI_SUCCESS == GetOfflineDumpRedactionScratchBufferLength(highestPhysicalAddress, &size));
     if (size != expectedSize) {
         TestErr("RedactionScratchBufferLength: address 0x%llX, expected 0x%X, actual 0x%X",
@@ -22,15 +22,26 @@ RedactionScratchBufferLengthTest()
     static UINT64 const MaxAddress = 0x7FFDFFFFFFFF;
     UINT32 size;
     
-    // Test error cases (size can't fit in UINT32)
+    // Error cases: size can't fit in UINT32
     size = 0;
     TestAssert(EFI_INVALID_PARAMETER == GetOfflineDumpRedactionScratchBufferLength(~(UINT64)0, &size));
-    TestAssert(size == 0xFFFFF000);
+    TestAssert(size == MAX_UINT32);
     size = 0;
-    TestAssert(EFI_INVALID_PARAMETER == GetOfflineDumpRedactionScratchBufferLength(MaxAddress + 1, &size));
-    TestAssert(size == 0xFFFFF000);
+    TestAssert(EFI_INVALID_PARAMETER == GetOfflineDumpRedactionScratchBufferLength(MaxAddress + 4096, &size));
+    TestAssert(size == MAX_UINT32);
 
-    TestSimple(0, 1, 1); // Minimum.
+    // Error cases: addr not aligned to PAGE_SIZE
+    size = 0;
+    TestAssert(EFI_INVALID_PARAMETER == GetOfflineDumpRedactionScratchBufferLength(0, &size));
+    TestAssert(size == MAX_UINT32);
+    size = 0;
+    TestAssert(EFI_INVALID_PARAMETER == GetOfflineDumpRedactionScratchBufferLength(1, &size));
+    TestAssert(size == MAX_UINT32);
+    size = 0;
+    TestAssert(EFI_INVALID_PARAMETER == GetOfflineDumpRedactionScratchBufferLength(4094, &size));
+    TestAssert(size == MAX_UINT32);
+
+    TestSimple(4095, 1, 1); // Minimum.
     TestSimple(0x20BFFFFFFF, 1, 33); // 131GB
     TestSimple(MaxAddress, 32, 32766); // 127.9TB
 }


### PR DESCRIPTION
- Private: Minor cleanup in RedactionBitmap - rename "Mark" to "MarkRange", add an "ExposePage" function, expose constants needed for computing "Scratch Buffer Length", const-correctness.
- Public: add support for computing "Scratch Buffer Length" in cases where the memory map has large holes.
- Error-checking: Validate that CpuContextSize % 8 == 0, etc.